### PR TITLE
step indicator tweaks

### DIFF
--- a/_includes/step-indicator.html
+++ b/_includes/step-indicator.html
@@ -17,7 +17,7 @@
       </li>
     </ol>
     <div class="usa-step-indicator__header">
-      <span class="usa-step-indicator__heading tablet:display-none font-sans-md">
+      <span class="usa-step-indicator__heading tablet:display-none font-sans-md text-primary">
         <span class="usa-step-indicator__heading-text">Before you file</span>
       </span>
     </div>

--- a/_includes/step-indicator.html
+++ b/_includes/step-indicator.html
@@ -17,7 +17,7 @@
       </li>
     </ol>
     <div class="usa-step-indicator__header">
-      <h4 class="usa-step-indicator__heading">
+      <h4 class="usa-step-indicator__heading tablet:display-none">
         <span class="usa-step-indicator__heading-text">Before you file</span>
       </h4>
     </div>

--- a/_includes/step-indicator.html
+++ b/_includes/step-indicator.html
@@ -18,11 +18,6 @@
     </ol>
     <div class="usa-step-indicator__header">
       <h4 class="usa-step-indicator__heading">
-        <span class="usa-step-indicator__heading-counter">
-          <span class="usa-sr-only">Step</span>
-          <span class="usa-step-indicator__current-step">1</span>
-          <span class="usa-step-indicator__total-steps">of 5</span>
-        </span>
         <span class="usa-step-indicator__heading-text">Before you file</span>
       </h4>
     </div>

--- a/_includes/step-indicator.html
+++ b/_includes/step-indicator.html
@@ -17,8 +17,8 @@
       </li>
     </ol>
     <div class="usa-step-indicator__header">
-      <h4 class="usa-step-indicator__heading tablet:display-none">
+      <span class="usa-step-indicator__heading tablet:display-none font-sans-md">
         <span class="usa-step-indicator__heading-text">Before you file</span>
-      </h4>
+      </span>
     </div>
   </div>

--- a/_includes/step-indicator.html
+++ b/_includes/step-indicator.html
@@ -13,7 +13,7 @@
         <span class="usa-step-indicator__segment-label">Supporting documentation<span class="usa-sr-only">not completed</span></span>
       </li>
       <li class="usa-step-indicator__segment">
-        <span class="usa-step-indicator__segment-label">Review and submit <span class="usa-sr-only">not completed</span></span>
+        <span class="usa-step-indicator__segment-label">Sign and submit <span class="usa-sr-only">not completed</span></span>
       </li>
     </ol>
     <div class="usa-step-indicator__header">


### PR DESCRIPTION
This is a change to one step indicator label to match success page copy. It may be obsolete depending on where we end up with "progress" issue.